### PR TITLE
Add root warning

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -56,10 +56,13 @@ function fish_prompt
   end 
   # Time
   set -l __time $white'['(date +%H:%M:%S)']'
-
-
+  # Root warning
+  set -l __user_color $blue
+  if test "$__fish_user" = "#"
+    set __user_color (set_color white -b red -o)
+  end
   # Line
-  echo -sne '\n'$purple$__fish_user' '$blue$USER$white \
+  echo -sne '\n'$purple$__fish_user' '$__user_color$USER$normal$white \
     ' @ '$green$__fish_prompt_hostname$white \
     ' in '$yellow$__work_dir$turquoise \
     (__fish_git_prompt) \


### PR DESCRIPTION
When `$USER` is root, there will be a different `root` string  instead original one. The new one is white-foreground-color, red-background-color with a bold font.
This may let users know more about what they are doing.