### PR TITLE
Fix for obsolete `__fish_prompt_hostname` implementation

### DIFF
--- a/fish_prompt.fish
+++ b/fish_prompt.fish
@@ -3,7 +3,7 @@ function fish_prompt
 
   # Just calculate these once, to save a few cycles when displaying the prompt
   if not set -q __fish_prompt_hostname
-    set -g __fish_prompt_hostname (hostname|cut -d . -f 1)
+    set -g __fish_prompt_hostname (echo $hostname)
   end
   if not set -q __fish_user
     switch (id -u)


### PR DESCRIPTION
See https://github.com/fish-shell/fish-shell/issues/7370

Replaced `(hostname|cut -d . -f 1)` which does not work on some later versions of fish with `(echo $hostname)`.
